### PR TITLE
Change default frame to LISA frame

### DIFF
--- a/BBHX_PhenomD.py
+++ b/BBHX_PhenomD.py
@@ -34,7 +34,7 @@ def bbhx_fd(ifos=None, run_phenomd=True, nyquist_freq=0.1,
     t_ref = params['tc']
 
     if ref_frame == 'LISA':
-        # Transform to LISA frame
+        # Transform to SSB frame
         t_ref, lam, beta, psi = LISA_to_SSB(
             t_ref,
             lam,

--- a/BBHX_PhenomD.py
+++ b/BBHX_PhenomD.py
@@ -16,6 +16,7 @@ def bbhx_fd(ifos=None, run_phenomd=True, nyquist_freq=0.1,
     import numpy as np
     from pycbc.types import FrequencySeries, Array
     from pycbc import pnutils
+    from bbhx.utils.transform import LISA_to_SSB
 
     wave_gen = get_waveform_genner(run_phenomd=run_phenomd)
 


### PR DESCRIPTION
Here's a change to do points 1 and 5 of the actions discussed in SLACK. Specifically this:

* Changes the default frame to the LISA frame (allowing one to use the SSB frame if specified as a kwarg).
* Caches the wave_gen object so we don't do the same thing *every* time we generate a waveform, which is not negligible cost!