### PR TITLE
add imr_duration function

### DIFF
--- a/BBHX_PhenomD.py
+++ b/BBHX_PhenomD.py
@@ -25,6 +25,16 @@ def chirptime(m1, m2, f_lower):
     duration = findchirp_chirptime(m1=m1, m2=m2, fLower=f_lower, porder=7)
     return duration
 
+def imr_duration(m1, m2, s1z, s2z, f_lower):
+    # More accurate duration of the waveform, including merge, ringdown,
+    # and aligned spin effects.
+    import lal
+    from pycbc import libutils
+    lalsimulation = libutils.import_optional('lalsimulation')
+    time_length = lalsimulation.SimIMRPhenomDChirpTime(
+                        m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, s1z, s2z, f_lower)
+    return time_length * 1.1
+
 def interpolated_tf(m1, m2):
     # Using findchirp_chirptime in PyCBC to calculate 
     # the time-frequency track of dominant mode to get

--- a/BBHX_PhenomD.py
+++ b/BBHX_PhenomD.py
@@ -36,11 +36,11 @@ def imr_duration(**params):
                'spin1z':params['spin1z'], 'spin2z':params['spin2z'],
                'f_lower':params['f_lower']}
     time_length = np.float64(imrphenomd_length_in_time(**nparams))
-    if time_length < 0:
-        warnings.warn("Negative duration! Reset it to 1 month (2678400 s).")
+    if time_length < 2678400:
+        warnings.warn("Waveform duration is too short! Setting it to 1 month (2678400 s).")
         time_length = 2678400
     if time_length >= params['t_obs_start']:
-        warnings.warn("Longer than data length! Reset it to `t_obs_start`.")
+        warnings.warn("Waveform duration is longer than data length! Setting it to `t_obs_start`.")
         time_length = params['t_obs_start']
     return time_length * 1.1
 

--- a/BBHX_PhenomD.py
+++ b/BBHX_PhenomD.py
@@ -28,12 +28,13 @@ def chirptime(m1, m2, f_lower):
 def imr_duration(m1, m2, s1z, s2z, f_lower):
     # More accurate duration of the waveform, including merge, ringdown,
     # and aligned spin effects.
-    import lal
-    from pycbc import libutils
-    lalsimulation = libutils.import_optional('lalsimulation')
-    time_length = lalsimulation.SimIMRPhenomDChirpTime(
-                        m1 * lal.MSUN_SI, m2 * lal.MSUN_SI, s1z, s2z, f_lower)
-    return time_length * 1.1
+    from pycbc.waveform.waveform import imrphenomd_length_in_time
+
+    params = {'mass1':m1, 'mass2':m2, 'spin1z':s1z, 'spin2z':s2z, 'f_lower':f_lower}
+    time_length = np.float64(imrphenomd_length_in_time(**params))
+    if time_length < 0:
+        raise ValueError("Negative duration!")
+    return time_length
 
 def interpolated_tf(m1, m2):
     # Using findchirp_chirptime in PyCBC to calculate 

--- a/BBHX_PhenomD.py
+++ b/BBHX_PhenomD.py
@@ -4,7 +4,7 @@ import numpy as np
 from scipy.interpolate import interp1d
 from bbhx.utils.constants import MTSUN_SI, YRSID_SI
 from bbhx.waveformbuild import BBHWaveformFD
-from bbhx.utils.transform import LISA_to_SSB
+from bbhx.utils.transform import LISA_to_SSB, SSB_to_LISA
 
 
 @functools.lru_cache(maxsize=128)
@@ -98,16 +98,22 @@ def bbhx_fd(ifos=None, run_phenomd=True,
     wave_gen = get_waveform_genner(log_mf_min, run_phenomd=run_phenomd)
 
     if ref_frame == 'LISA':
+        t_ref_lisa = t_ref
         # Transform to SSB frame
         t_ref, lam, beta, psi = LISA_to_SSB(
-            t_ref,
+            t_ref_lisa,
             lam,
             beta,
             psi
         )
     elif ref_frame == 'SSB':
         # Don't need to update variable names
-        pass
+        t_ref_lisa, _, _, _ = SSB_to_LISA(
+            t_ref,
+            lam,
+            beta,
+            psi
+        )
     else:
         err_msg = f"Don't recognise reference frame {ref_frame}. "
         err_msg = f"Known frames are 'LISA' and 'SSB'."
@@ -151,14 +157,14 @@ def bbhx_fd(ifos=None, run_phenomd=True,
     # Convert outputs to PyCBC arrays
     if sample_points is None:
         length_of_wave = t_obs_start
-        loc_of_signal_merger_within_wave = t_ref % length_of_wave
+        loc_of_signal_merger_within_wave = t_ref_lisa % length_of_wave
         df = 1 / t_obs_start
 
         for channel, tdi_num in wanted.items():
             output[channel] = FrequencySeries(
                 wave[tdi_num],
                 delta_f=df,
-                epoch=params['tc'] - loc_of_signal_merger_within_wave,
+                epoch=t_ref_lisa - loc_of_signal_merger_within_wave,
                 copy=False
             )
     else:

--- a/BBHX_PhenomD.py
+++ b/BBHX_PhenomD.py
@@ -25,16 +25,21 @@ def chirptime(m1, m2, f_lower):
     duration = findchirp_chirptime(m1=m1, m2=m2, fLower=f_lower, porder=7)
     return duration
 
-def imr_duration(m1, m2, s1z, s2z, f_lower):
-    # More accurate duration of the waveform, including merge, ringdown,
-    # and aligned spin effects.
+def imr_duration(**params):
+    # More accurate duration (within LISA frequency band) of the waveform,
+    # including merge, ringdown, and aligned spin effects.
+    # This is used in the time-domain signal injection in PyCBC.
+    import warnings
     from pycbc.waveform.waveform import imrphenomd_length_in_time
 
-    params = {'mass1':m1, 'mass2':m2, 'spin1z':s1z, 'spin2z':s2z, 'f_lower':f_lower}
     time_length = np.float64(imrphenomd_length_in_time(**params))
     if time_length < 0:
-        raise ValueError("Negative duration!")
-    return time_length
+        warnings.warn("Negative duration! Reset it to 1 month (2678400 s).")
+        time_length = 2678400
+    if time_length >= params['t_obs_start']:
+        warnings.warn("Longer than data length! Reset it to `t_obs_start`.")
+        time_length = params['t_obs_start']
+    return time_length * 1.1
 
 def interpolated_tf(m1, m2):
     # Using findchirp_chirptime in PyCBC to calculate 

--- a/BBHX_PhenomD.py
+++ b/BBHX_PhenomD.py
@@ -56,8 +56,8 @@ def bbhx_fd(ifos=None, run_phenomd=True,
     from pycbc.types import FrequencySeries, Array
     from pycbc import pnutils
 
-    m1 = params['mass1']
-    m2 = params['mass2']
+    m1 = np.float64(params['mass1'])
+    m2 = np.float64(params['mass2'])
     a1 = params['spin1z']
     a2 = params['spin2z']
     dist = pnutils.megaparsecs_to_meters(params['distance'])

--- a/BBHX_PhenomD.py
+++ b/BBHX_PhenomD.py
@@ -32,7 +32,10 @@ def imr_duration(**params):
     import warnings
     from pycbc.waveform.waveform import imrphenomd_length_in_time
 
-    time_length = np.float64(imrphenomd_length_in_time(**params))
+    nparams = {'mass1':params['mass1'], 'mass2':params['mass2'],
+               'spin1z':params['spin1z'], 'spin2z':params['spin2z'],
+               'f_lower':params['f_lower']}
+    time_length = np.float64(imrphenomd_length_in_time(**nparams))
     if time_length < 0:
         warnings.warn("Negative duration! Reset it to 1 month (2678400 s).")
         time_length = 2678400

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup (
     keywords = ['pycbc', 'signal processing', 'gravitational waves', 'lisa'],
     install_requires = ['pycbc'],
     py_modules = ['BBHX_PhenomD'],
-    entry_points = {"pycbc.waveform.fd_det_sequence":"BBHX_PhenomD=BBHX_PhenomD:bbhx_fd",
+    entry_points = {"pycbc.waveform.fd_det":"BBHX_PhenomD=BBHX_PhenomD:bbhx_fd",
+                    "pycbc.waveform.fd_det_sequence":"BBHX_PhenomD=BBHX_PhenomD:bbhx_fd",
                     "pycbc.waveform.length":"BBHX_PhenomD=BBHX_PhenomD:imr_duration"},
 
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup (
     keywords = ['pycbc', 'signal processing', 'gravitational waves', 'lisa'],
     install_requires = ['pycbc'],
     py_modules = ['BBHX_PhenomD'],
-    entry_points = {"pycbc.waveform.fd_det_sequence":"BBHX_PhenomD=BBHX_PhenomD:bbhx_fd"},
+    entry_points = {"pycbc.waveform.fd_det_sequence":"BBHX_PhenomD=BBHX_PhenomD:bbhx_fd",
+                    "pycbc.waveform.length":"BBHX_PhenomD=BBHX_PhenomD:imr_duration"},
 
     classifiers=[
         'Programming Language :: Python',


### PR DESCRIPTION
@spxiwh In this PR, I add a more accurate function to calculate the IMR duration of the signal. This is useful for the time-domain signal injection for LISA in PyCBC (work in progress).